### PR TITLE
Added dark mode 🎨

### DIFF
--- a/src/app/components/mode-toggle/ModeToggle.tsx
+++ b/src/app/components/mode-toggle/ModeToggle.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import * as React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { Button } from '@/ui/button';
+
+export function ModeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <>
+      {theme === 'dark' && (
+        <Button
+          variant='outline'
+          size='icon'
+          onClick={() => setTheme('light')}
+          aria-label='Light mode'
+          className='shadow-yellow-500'
+        >
+          <Sun className='h-[1.2rem] w-[1.2rem]' />
+        </Button>
+      )}
+      {theme === 'light' && (
+        <Button
+          variant='outline'
+          size='icon'
+          onClick={() => setTheme('dark')}
+          aria-label='Dark mode'
+          className='shadow-blue-900'
+        >
+          <Moon className=' h-[1.2rem] w-[1.2rem]' />
+        </Button>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Added light and dark mode theme from `next-themes` and it is enclosed in a component called `ModeToggle`. This renders sun icon in dark mode and moon icon in light mode to change to light and dark mode respectively.